### PR TITLE
#4 added property to ignore javadoc errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.organization>Vaadin</project.organization>
-    </properties>
+        <maven.javadoc.failOnError>false</maven.javadoc.failOnError> 
+   </properties>
 
     <licenses>
         <license>


### PR DESCRIPTION
- https://github.com/vaadin/sass-compiler/issues/4
